### PR TITLE
Fixing missing zip command

### DIFF
--- a/redirector/Dockerfile
+++ b/redirector/Dockerfile
@@ -5,7 +5,8 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local
 
 # Install Mongo drivers
 RUN apt update
-RUN apt install -y libcurl4-openssl-dev pkg-config libssl-dev git
+RUN apt install -y libcurl4-openssl-dev pkg-config libssl-dev git zip unzip
+
 RUN pecl install mongodb
 RUN echo 'extension=mongodb.so' > /usr/local/etc/php/php.ini
 


### PR DESCRIPTION
The redirector pod fails installing composer due to missing zip/unzip command. Installing it in the image fix the issue